### PR TITLE
Adding npm postinstall option to run bower install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run karma",
-    "karma": "NODE_ENV=test gulp karma"
+    "karma": "NODE_ENV=test gulp karma",
+    "postinstall": "bower install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A bower install is the missing step to getting the examples up and running - this handles that step automatically.
